### PR TITLE
Dump BIOS every 1KB size

### DIFF
--- a/bios-dumper.asm
+++ b/bios-dumper.asm
@@ -116,12 +116,11 @@ FILE_COUNT = 5
 .import __FILE4_DAT_RUN__
 .byte $03
 .byte 4,$FF
-.byte "DISKSYS-"
+.byte "DISKSYS0"
 .word __FILE4_DAT_RUN__
 .word __FILE4_DAT_SIZE__
 .byte 0 ; PRG
 ; block 4
 .byte $04
 .segment "FILE4_DAT"
-.res $2000, $FF ; fill with $FF to make it easier to find within the disk
-
+.res $0400, $FF ; fill with $FF to make it easier to find within the disk

--- a/bios-dumper.cfg
+++ b/bios-dumper.cfg
@@ -10,7 +10,7 @@ MEMORY {
     VEC1:    start = $DFF6, size = $000A, type = rw, file = "";
     CHR2:    start = $0000, size = $1000, type = rw, file = "";
 	CHK3:    start = $2000, size = $0001, type = rw, file = "";
-	CHK4:    start = $E000, size = $2000, type = rw, file = "";
+	CHK4:    start = $E000, size = $0400, type = rw, file = "";
 }
 
 SEGMENTS {

--- a/ram.asm
+++ b/ram.asm
@@ -9,6 +9,8 @@
 	NeedPPUMask: .res 1
 	BGMode: .res 1
 	StringStatus: .res 1
+	FileHeader: .res 17
+	FileNum: .res 1
 
 ; BIOS zeropage variables
 .segment "BIOSZP": zeropage


### PR DESCRIPTION
Heya, I just found your fork today and this seems like a neat addition! I'm guessing this might make the dumping process more robust on drives/RAM adapters with write protection measures? I just want to tweak the code a bit and document the feature properly before merging this. 

Also, thanks for testing it on real hardware. I have a Twin Famicom myself but lack the tools for loading FDS programs at the moment. 